### PR TITLE
Update cookiecutter syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 Prerequisites: [`cookiecutter`](https://github.com/cookiecutter/cookiecutter)
 
 ```bash
-cookiecutter gh:runtimeverification/python-project-template.git
+cookiecutter gh:runtimeverification/python-project-template
 ```


### PR DESCRIPTION
The `.git` suffix isn't valid here for cookiecutter.