### PR TITLE
Adding a templated release workflow to run on manual dispatch, for no…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,26 +6,65 @@ on:
       feature/release-publish-workflow
 
 jobs:
-  build-n-publish:
-    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
-    runs-on: ubuntu-latest
-
+  template-generation:
+    name: 'Generate Template'
+    runs-on: [self-hosted, linux, normal-ephemeral]
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.x"
+      - name: 'Check out code'
+        uses: actions/checkout@v3
 
-    - name: Publish distribution 📦 to Test PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_DEPLOY_TOKEN_TEST }}
-        repository-url: https://test.pypi.org/legacy/
+      - name: 'Install Python'
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
-    # - name: Publish distribution 📦 to PyPI
-    #   if: startsWith(github.ref, 'refs/tags')
-    #   uses: pypa/gh-action-pypi-publish@release/v1
-    #   with:
-    #     password: ${{ secrets.PYPI_DEPLOY_TOKEN }}
+      - name: 'Install cookiecutter'
+        run: pip install cookiecutter
+
+      - name: 'Install Poetry'
+        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.3.2
+
+      - name: 'Generate template'
+        run: cookiecutter --no-input . project_name='Test Project'
+
+      - name: 'Generate lock file'
+        run: poetry -C ./test-project lock
+
+      - name: 'Cache generated project'
+        uses: actions/cache@v3
+        with:
+          path: ./test-project
+          key: test-project-${{ github.run_id }}
+
+  template-tests-release-publish:
+    name: 'Test Release Publish Python 🐍 distributions 📦 to TestPyPI'
+    needs: template-generation
+    runs-on: [self-hosted, normal-ephemeral]
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
+    steps:
+      - name: 'Install Python'
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: 'Install Poetry'
+        run: curl -sSL https://install.python-poetry.org | python3 - --version 1.3.2
+
+      - name: 'Restore generated project'
+        uses: actions/cache@v3
+        with:
+          path: ./test-project
+          key: test-project-${{ github.run_id }}
+      
+      - name: 'Build & Package'
+        run: |
+          make all
+          pip wheel .
+      
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         run: curl -sSL https://install.python-poetry.org | python3 - --version 1.3.2
 
       - name: 'Generate template'
-        run: cookiecutter --no-input . project_name='Test Project'
+        run: cookiecutter --no-input . project_name='Test Project' description='Test Description' author='Test Author' version='0.0.1'
 
       - name: 'Generate lock file'
         run: poetry -C ./test-project lock

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   template-generation:
     name: 'Generate Template'
-    runs-on: [self-hosted, linux, normal-ephemeral]
+    runs-on: ubuntu-latest
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v3
@@ -39,7 +39,7 @@ jobs:
   template-tests-release-publish:
     name: 'Test Release Publish Python 🐍 distributions 📦 to TestPyPI'
     needs: template-generation
-    runs-on: [self-hosted, normal-ephemeral]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ['3.10', '3.11']
@@ -58,7 +58,7 @@ jobs:
           path: ./test-project
           key: test-project-${{ github.run_id }}
       
-      - name: 'Build & Package'
+      - name: 'Build, Package, Publish'
         run: |
           poetry build
           poetry test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,11 +60,6 @@ jobs:
       
       - name: 'Build & Package'
         run: |
-          make all
-          pip wheel .
-      
-      - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
+          poetry build
+          poetry test
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,4 +68,5 @@ jobs:
           cd ./test-project
           poetry build
 
-          
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,10 +63,10 @@ jobs:
           path: ./test-project
           key: test-project-${{ github.run_id }}
       
-      - name: 'Build, Package, Publish'
+      - name: 'Package'
         run: |
           cd ./test-project
           poetry build
 
-      - name: Publish package distributions to PyPI
+      - name: Publish package distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+on: 
+  workflow_dispatch:
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_DEPLOY_TOKEN_TEST }}
+        repository-url: https://test.pypi.org/legacy/
+
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_DEPLOY_TOKEN }}
+        

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,7 @@ jobs:
       
       - name: 'Build, Package, Publish'
         run: |
+          cd ./test-project
           poetry build
-          poetry test
+          poetry publish
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,3 +70,6 @@ jobs:
 
       - name: Publish package distributions to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,4 +72,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-          
+          packages-dir: ./test-project/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,9 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 on: 
   workflow_dispatch:
+  push:
+    branches:
+      feature/release-publish-workflow
 
 jobs:
   build-n-publish:
@@ -20,9 +23,9 @@ jobs:
         password: ${{ secrets.PYPI_DEPLOY_TOKEN_TEST }}
         repository-url: https://test.pypi.org/legacy/
 
-    - name: Publish distribution 📦 to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PYPI_DEPLOY_TOKEN }}
+    # - name: Publish distribution 📦 to PyPI
+    #   if: startsWith(github.ref, 'refs/tags')
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     password: ${{ secrets.PYPI_DEPLOY_TOKEN }}
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.10', '3.11']
+    environment:
+      name: release
+      url: https://test.pypi.org/RuntimeVerificationTest
+    permissions:
+      id-token: write
     steps:
       - name: 'Install Python'
         uses: actions/setup-python@v4
@@ -62,5 +67,5 @@ jobs:
         run: |
           cd ./test-project
           poetry build
-          poetry publish
-        
+
+          


### PR DESCRIPTION
In Relation to https://github.com/runtimeverification/devops/issues/108

Adding template for release workflow only with manual deploy execution for python packages 

Documentation followed for workflow [recommendation by Pypi ](https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/)